### PR TITLE
Solving #1 and #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,55 @@ service.onChange(ctx => console.log(ctx))
 */
 
 ```
+### Enhanced context
+
+1. *match:*
+Tells you whether the route in the location matches the current state's path. If it matches it contains an object holding properties for each route parameter's value if the path was parameterized. Examples: `null` (not matching), `{}` (no parameters), `{ param1: 4711 }`
+1. *location:*
+The current value of `history.location`
+1. *history:*
+`routerMachine(...)` accepts a history object as fourth parameter. If it is missing it defaults to `createBrowserHistory()` (from package `'history'`) and is published in the context.
+
+if you translate to a state having a parameterized route then you have to ensure that context.match contains the values of those parameters. Otherwise the placeholder is shown in the route. Example:
+```javascript
+  states: {
+      list: { meta: { path: '/items' },
+         on: {
+            ShowDetails: {
+                target: 'details',
+                actions: assign((ctx, event) => ({
+                                    ...ctx,
+                                    match: { id: event.item }
+                                }))
+            }
+         }
+      }
+      details: { meta: { path: '/items/:id:/details'} }
+  }
+```
+where the event trigger could look like this:
+```html
+<button onClick={() => this.send('ShowDetails', { item: 817 })}>Show details...</button>
+```
+
+### Router events
+
+If a route changes then a parameterized event `'route-changed'` is fired: e.g. `{ dueToStateTransition: "true", route: "/blog", service: /* the xstate interpreter */ }`. 
+1. If the route changes because a state is entered which has a route configured, then `dueToStateTransition` is `true`. If the route changes because the location was changed (either by the user in the browsers location bar or by a script changing `history.location`), then `dueToStateTransition` is `false`.
+1. `route` gives you the current route which causes the event
+1. `service` provides the xstate interpreter which can be used to send another event.
+
+Placing an `on: 'router-changed'` event at a state can be used to avoid leaving the current state if the route changes. Think of a state which might show unsaved data and you want to ask the user *'Leave and loose unsaved data?'*. If you decide to accept the new route anyway you have to resend the event:
+```javascript
+  on: {
+    'route-changed': {
+      cond: (context, event) => event.dueToStateTransition === false
+          && !event.processed,            // interfere only new events
+      actions: (context, event) => {
+        if (context.unsavedData) return;  // suppress current route change
+        event.processed = true;           // mark event as processed
+        event.service.send(event);        // resend the event to establish the origin route change
+      }
+    }
+  },
+```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
-    "build": "tsc"
+    "build": "tsc",
+    "build:watch": "tsc --watch"
   },
   "peerDependencies": {
     "xstate": "^4.2.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xstate-router",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "XState Router. Add routes to your XState machine.",
   "main": "lib/index.js",
   "files": [

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -30,7 +30,20 @@ const machineConfig = {
       meta: { path: '/' },
     },
     about: {
-      meta: { path: '/about' }
+      meta: { path: '/about' },
+      on: {
+          'route-changed': [{
+              cond: (context, event) => event.refresh === false
+                                        && event.route 
+                                        && event.route === '/substate/a',
+              target: 'substate.c'
+          },
+          {
+              cond: (context, event) => event.refresh === false
+                                        && event.route 
+                                        && event.route === '/substate/b'
+          }]
+      }
     },
     substate: {
       meta: { path: '/substate' },
@@ -40,6 +53,7 @@ const machineConfig = {
           meta: { path: '/substate/a' }
         },
         b: {},
+        c: {}
       }
     },
     noMatch: {
@@ -116,6 +130,20 @@ describe('XStateRouter', () => {
     fireEvent.click(getByTestId('go-about'))
     history.goBack()
     expect(getByTestId('state').textContent).toBe('home')
+  })
+
+  it('When enter a routable state, should be able to redirect state update', () => {
+    const { getByTestId, history } = renderWithRouter(App)
+    fireEvent.click(getByTestId('go-about'))
+    history.replace('/substate/a');
+    expect(getByTestId('state').textContent).toBe('substate.c')
+  })
+
+  it('When enter a routable state, should be able to stop state update', () => {
+    const { getByTestId, history } = renderWithRouter(App)
+    fireEvent.click(getByTestId('go-about'))
+    history.replace('/substate/b');
+    expect(getByTestId('state').textContent).toBe('about')
   })
 
   it('When enter a substate of a routable state from other routable state, should update the route', () => {

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -33,13 +33,13 @@ const machineConfig = {
       meta: { path: '/about' },
       on: {
           'route-changed': [{
-              cond: (context, event) => event.refresh === false
+              cond: (context, event) => event.dueToStateTransition === false
                                         && event.route 
                                         && event.route === '/substate/a',
               target: 'substate.c'
           },
           {
-              cond: (context, event) => event.refresh === false
+              cond: (context, event) => event.dueToStateTransition === false
                                         && event.route 
                                         && event.route === '/substate/b'
           }]
@@ -135,14 +135,14 @@ describe('XStateRouter', () => {
   it('When enter a routable state, should be able to redirect state update', () => {
     const { getByTestId, history } = renderWithRouter(App)
     fireEvent.click(getByTestId('go-about'))
-    history.replace('/substate/a');
+    history.replace('/substate/a')
     expect(getByTestId('state').textContent).toBe('substate.c')
   })
 
   it('When enter a routable state, should be able to stop state update', () => {
     const { getByTestId, history } = renderWithRouter(App)
     fireEvent.click(getByTestId('go-about'))
-    history.replace('/substate/b');
+    history.replace('/substate/b')
     expect(getByTestId('state').textContent).toBe('about')
   })
 

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { render, fireEvent, cleanup } from 'react-testing-library'
 import { createMemoryHistory } from 'history'
+import { MachineOptions } from 'xstate'
 import { toStatePaths } from 'xstate/lib/utils'
 import { routerMachine } from './index'
 
@@ -47,7 +48,7 @@ const machineConfig = {
   }
 }
 
-const options = {}
+const options: MachineOptions<any, any> = {} as MachineOptions<any, any>
 
 const initialContext = {}
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,10 +48,10 @@ export function addRouterEvents(history, configObj, routes) {
   } else {
     config.on = { ...config.on }
   }
-  const given: any = routerEvent in config.on ? config.on[routerEvent] : [];
-  const on: any = given instanceof Array ? given : [given];
+  const given: any = routerEvent in config.on ? config.on[routerEvent] : []
+  const on: any = given instanceof Array ? given : [given]
   on.push({
-    cond: (context, event) => event.refresh,
+    cond: (context, event) => event.dueToStateTransition,
     actions: assign(ctx => ({
       ...ctx,
       location: history.location,
@@ -61,15 +61,15 @@ export function addRouterEvents(history, configObj, routes) {
   for (const route of routes) {
       on.push({
         target: '#(machine).' + route[0].join('.'),
-        cond: (context, event) => event.refresh === false && event.route && event.route === route[1],
+        cond: (context, event) => event.dueToStateTransition === false && event.route && event.route === route[1],
         actions: assign(ctx => ({
             ...ctx,
             location: history.location,
             match: matchURI(route[1], history.location.pathname)
         }))
-      });
+      })
   }
-  config.on[routerEvent] = on;
+  config.on[routerEvent] = on
   return config
 }
 
@@ -120,7 +120,7 @@ export function routerMachine<
     if (!matchURI(path, history.location.pathname)) {
       debounceHistoryFlag = true
       history.push(path)
-      service.send({ type: routerEvent, refresh: true, route: path, service: service })
+      service.send({ type: routerEvent, dueToStateTransition: true, route: path, service: service })
     }
   })
 
@@ -145,7 +145,7 @@ export function routerMachine<
     }
     if (matchingRoute) {
       debounceState = matchingRoute[1]  // debounce only for this route
-      service.send({ type: routerEvent, refresh: false, route: matchingRoute[1], service: service })
+      service.send({ type: routerEvent, dueToStateTransition: false, route: matchingRoute[1], service: service })
       const state = service.state.value
       if (!matchesState(state, matchingRoute[0].join('.'))) {
         const stateNode = service.machine.getStateNodeByPath(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,17 +23,17 @@ export function buildURI(path: string, match: any) {
     const pattern: RegExp = toRegex(path, keys) // TODO: Use caching
     const regexp = pattern.exec(path)
     if (!regexp) return path
-    let result = '';
-    var lastIndex = 0;
+    let result = ''
+    var lastIndex = 0
     for (let i = 1; i < regexp.length; i++) {
-        const param: string = regexp[i];           // e.g. :whatever
-        const paramName: string = param.substr(1); // e.g. whatever
-        const pos: number = path.indexOf(param, lastIndex);
-        result += path.substring(lastIndex, pos) + match[paramName];
-        lastIndex = pos + param.length;
+        const param: string = regexp[i]           // e.g. :whatever
+        const paramName: string = param.substr(1) // e.g. whatever
+        const pos: number = path.indexOf(param, lastIndex)
+        result += path.substring(lastIndex, pos) + match[paramName]
+        lastIndex = pos + param.length
     }
     result += path.substr(lastIndex)
-    return result;
+    return result
 }
 
 export function resolve(routes, location, handleError?: boolean) {
@@ -138,7 +138,7 @@ export function routerMachine<
     }
     if (!matchURI(path, history.location.pathname)) {
       debounceHistoryFlag = true
-      const uri = buildURI(path, state.context.match);
+      const uri = buildURI(path, state.context.match)
       history.push(uri)
       service.send({ type: routerEvent, dueToStateTransition: true, route: path, service: service })
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,7 +48,8 @@ export function addRouterEvents(history, configObj, routes) {
   } else {
     config.on = { ...config.on }
   }
-  const on: any = []
+  const given: any = routerEvent in config.on ? config.on[routerEvent] : [];
+  const on: any = given instanceof Array ? given : [given];
   on.push({
     cond: (context, event) => event.refresh,
     actions: assign(ctx => ({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,25 @@ export function matchURI(path, uri) {
   return params
 }
 
+
+export function buildURI(path: string, match: any) {
+    const keys: any = []
+    const pattern: RegExp = toRegex(path, keys) // TODO: Use caching
+    const regexp = pattern.exec(path)
+    if (!regexp) return path
+    let result = '';
+    var lastIndex = 0;
+    for (let i = 1; i < regexp.length; i++) {
+        const param: string = regexp[i];           // e.g. :whatever
+        const paramName: string = param.substr(1); // e.g. whatever
+        const pos: number = path.indexOf(param, lastIndex);
+        result += path.substring(lastIndex, pos) + match[paramName];
+        lastIndex = pos + param.length;
+    }
+    result += path.substr(lastIndex)
+    return result;
+}
+
 export function resolve(routes, location, handleError?: boolean) {
   for (const route of routes) {
     const uri = location.pathname
@@ -119,7 +138,8 @@ export function routerMachine<
     }
     if (!matchURI(path, history.location.pathname)) {
       debounceHistoryFlag = true
-      history.push(path)
+      const uri = buildURI(path, state.context.match);
+      history.push(uri)
       service.send({ type: routerEvent, dueToStateTransition: true, route: path, service: service })
     }
   })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -119,7 +119,7 @@ export function routerMachine<
     if (!matchURI(path, history.location.pathname)) {
       debounceHistoryFlag = true
       history.push(path)
-      service.send({ type: routerEvent, refresh: true, route: path })
+      service.send({ type: routerEvent, refresh: true, route: path, service: service })
     }
   })
 
@@ -144,7 +144,7 @@ export function routerMachine<
     }
     if (matchingRoute) {
       debounceState = matchingRoute[1]  // debounce only for this route
-      service.send({ type: routerEvent, refresh: false, route: matchingRoute[1] })
+      service.send({ type: routerEvent, refresh: false, route: matchingRoute[1], service: service })
       const state = service.state.value
       if (!matchesState(state, matchingRoute[0].join('.'))) {
         const stateNode = service.machine.getStateNodeByPath(


### PR DESCRIPTION
Hi Carlos,

Thank you for building this library, it was indeed a missing link on using xstate. Good routing is important because is it visible to the user! However, I reflected the usage of your library in my project's situations and came up with two issues: #1 and #2. This pull requests contains fixes for both of them because I wanted to test them in conjunction. For #2 alone you could also cherry-pick 2e4b879 (for the tests: 725f287 and 828b4a8).

Especially for #1 you might have your own opinion which I'm interested in. I changed the name of router events from 'Router_....' to a parameterized event 'route-changed'. As these events were only for internal usage I think it is OK and I wanted the event name to reflect what it is about since from now on it might appear in the users statecharts. I also updated the README.md to catch up the user.

I hope you like my contribution :-)

Cheers,
Stephan 