### PR TITLE
fix: history is not updated if uri template is the same but parameters differs

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -185,9 +185,10 @@ export function handleTransitionEvents (service, history, routes) {
       debounceState = false
       return
     }
-    if (!matchURI(path, history.location.pathname)) {
+
+    const uri = buildURI(path, state.context.match)
+    if (uri !==  history.location.pathname) {
       debounceHistoryFlag = true
-      const uri = buildURI(path, state.context.match)
       history.push(uri)
       service.send({ type: routerEvent, dueToStateTransition: true, route: path, service: service })
     }


### PR DESCRIPTION
current template: /path/:id and current history.location = '/path/1234'
we sending an event git get '/path/4321', but the history is not updated.

Unfortunately we are not able to exec the jest tests. they hang forever.
